### PR TITLE
chore: add contribution workflow

### DIFF
--- a/.claude/skills/create-commit/SKILL.md
+++ b/.claude/skills/create-commit/SKILL.md
@@ -1,0 +1,38 @@
+---
+name: create-commit
+description: Create a safe, focused Git commit for this repository. Use when the user asks to commit completed work, prepare a commit, or choose a Conventional Commit message. Inspect the working tree, stage only intended files, validate relevant changes, and create the commit without pushing.
+---
+
+# Create Commit
+
+Create small, reviewable commits that follow this repository's contribution rules. Do not push, amend, rebase, reset, or change branches unless the user explicitly asks.
+
+## Workflow
+
+1. Inspect `git status --short`, the staged and unstaged diffs, and recent commit messages.
+2. Determine the smallest coherent commit. Preserve unrelated user changes; never use `git add -A` or `git add .`.
+3. If the intended files or scope are unclear, ask the user before staging or committing.
+4. Stage only the chosen paths with `git add <path>...`.
+5. Select a Conventional Commit message. Prefer a scoped type when useful:
+
+   ```text
+   docs(scope): describe documentation change
+   feat(scope): describe user-facing addition
+   fix(scope): describe corrected behavior
+   test(scope): describe test change
+   chore(scope): describe maintenance work
+   ci: describe workflow change
+   ```
+
+   Use a concise, lowercase imperative subject with no final period. Reuse an explicit user-provided message if it is suitable.
+
+6. Run the relevant validation commands from `CONTRIBUTING.md` when they are practical for the changed files. Report any pre-existing or environment-related failure; do not conceal it by weakening checks.
+7. Review the staged diff one final time, then create the commit with `git commit -m "<message>"`.
+8. Confirm success with `git status --short` and `git log -1 --oneline`.
+
+## Safety rules
+
+- Do not commit secrets, generated output, local configuration, or unrelated files.
+- Do not modify existing commits, force-push, or push any branch as part of this skill.
+- Do not bypass hooks with `--no-verify` unless the user explicitly authorizes it after the failure is explained.
+- If validation fails because of the proposed change, fix it before committing when the user asked for a finished commit. If it is unrelated, report it clearly.

--- a/.claude/skills/create-commit/agents/openai.yaml
+++ b/.claude/skills/create-commit/agents/openai.yaml
@@ -1,0 +1,4 @@
+interface:
+  display_name: "Create Commit"
+  short_description: "Create safe, focused Git commits"
+  default_prompt: "Use $create-commit to review my changes and create a Conventional Commit."

--- a/.claude/skills/create-pr/SKILL.md
+++ b/.claude/skills/create-pr/SKILL.md
@@ -1,0 +1,33 @@
+---
+name: create-pr
+description: Prepare and open a safe GitHub pull request for this repository. Use when the user asks to create, open, or prepare a pull request from completed branch work. Inspect the branch and diff, validate changes, follow the repository PR template, push only when authorized, and open a draft PR by default.
+---
+
+# Create Pull Request
+
+Prepare reviewable pull requests for `main`. Keep the branch focused, preserve unrelated work, and never merge or modify another person's pull request.
+
+## Workflow
+
+1. Inspect the current branch, `git status --short`, the diff against `main`, recent commits, and any existing pull request for the branch.
+2. Confirm the branch is not `main` and that it contains a small, coherent change. If the scope, target branch, or included files are unclear, ask before proceeding.
+3. Ensure all intended work is committed. Use the `create-commit` skill if a commit is needed.
+4. Run the relevant validation commands from `CONTRIBUTING.md`. Report failures accurately; do not weaken checks or use bypass flags.
+5. Derive a concise Conventional Commit-style PR title, such as `docs(react): add testing resources`. Reuse a suitable user-provided title.
+6. Build the description from `.github/pull_request_template.md`:
+
+   - Explain what changed and why.
+   - Add `Closes #<number>` only when an issue is known.
+   - Mark only validation commands that actually passed.
+   - Keep unchecked items unchecked and do not claim work that was not performed.
+
+7. If the user asked to open the PR, push the current branch and create a **draft** pull request targeting `main`. Use GitHub CLI or an authenticated GitHub integration. If the user asked only to prepare it, provide the title and body without pushing or creating anything.
+8. Return the PR URL, target branch, title, validation results, and any limitations.
+
+## Safety rules
+
+- Do not push or create a PR unless the user explicitly requested that external action.
+- Do not use `--force`, alter branch history, merge, approve, or request review unless explicitly asked.
+- Do not include secrets, generated output, local configuration, or unrelated changes.
+- Do not create a duplicate PR. Update or report an existing PR instead.
+- Use `main` as the base branch unless the user specifies another target.

--- a/.claude/skills/create-pr/agents/openai.yaml
+++ b/.claude/skills/create-pr/agents/openai.yaml
@@ -1,0 +1,4 @@
+interface:
+  display_name: "Create Pull Request"
+  short_description: "Prepare and open safe GitHub pull requests"
+  default_prompt: "Use $create-pr to prepare my branch and open a draft pull request."

--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -1,0 +1,36 @@
+name: Report a bug
+description: Help us reproduce and fix a problem.
+title: "fix: "
+labels:
+  - bug
+body:
+  - type: markdown
+    attributes:
+      value: Thank you for taking the time to report this problem.
+  - type: textarea
+    id: description
+    attributes:
+      label: Problem description
+      description: Explain what happened and what you expected to happen.
+    validations:
+      required: true
+  - type: textarea
+    id: reproduce
+    attributes:
+      label: Steps to reproduce
+      placeholder: |
+        1. Go to ...
+        2. Click ...
+        3. See ...
+    validations:
+      required: true
+  - type: input
+    id: url
+    attributes:
+      label: Affected URL
+      description: Include the page URL, if applicable.
+  - type: textarea
+    id: environment
+    attributes:
+      label: Environment
+      description: Browser, operating system, and version, if applicable.

--- a/.github/ISSUE_TEMPLATE/content_suggestion.yml
+++ b/.github/ISSUE_TEMPLATE/content_suggestion.yml
@@ -1,0 +1,37 @@
+name: Suggest content or a resource
+description: Propose a topic, resource, or improvement for the guide.
+title: "docs: "
+labels:
+  - content
+body:
+  - type: markdown
+    attributes:
+      value: Thank you for helping improve the guide's resources.
+  - type: input
+    id: topic
+    attributes:
+      label: Topic or section
+      description: Tell us where the content should appear.
+    validations:
+      required: true
+  - type: textarea
+    id: proposal
+    attributes:
+      label: Proposal
+      description: Explain the content you propose and why it would be useful for technical interviews.
+    validations:
+      required: true
+  - type: textarea
+    id: resources
+    attributes:
+      label: Suggested resources
+      description: Share links and state the language of each resource.
+  - type: checkboxes
+    id: checks
+    attributes:
+      label: Checks
+      options:
+        - label: I verified that an equivalent suggestion does not already exist.
+          required: true
+        - label: The suggested resources are relevant and legitimately accessible.
+          required: true

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,30 @@
+## Summary
+
+Briefly describe what changed and why.
+
+## Related issue
+
+Closes #
+
+## Type of change
+
+- [ ] Documentation or content
+- [ ] Bug fix
+- [ ] New feature
+- [ ] Tests or maintenance
+
+## Validation
+
+- [ ] `npm run lint`
+- [ ] `npm run build`
+- [ ] `npm test`
+- [ ] `npm run verify:content` (if content changes)
+- [ ] `npm run check:links` (if content or links change)
+- [ ] `npm run test:e2e` (if the interface changes)
+
+## Checklist
+
+- [ ] My PR has a small scope and a clear title.
+- [ ] I followed [CONTRIBUTING.md](../CONTRIBUTING.md).
+- [ ] I did not include copyrighted content without permission.
+- [ ] I updated the necessary documentation.

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,46 @@
+name: CI
+
+on:
+  pull_request:
+  push:
+    branches:
+      - main
+
+permissions:
+  contents: read
+
+concurrency:
+  group: ci-${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  quality:
+    name: Quality checks
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@v4
+
+      - name: Set up Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: 22
+          cache: npm
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Lint
+        run: npm run lint
+
+      - name: Run unit tests
+        run: npm test
+
+      - name: Verify content migration
+        run: npm run verify:content
+
+      - name: Check reference links
+        run: npm run check:links
+
+      - name: Build site
+        run: npm run build

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,89 @@
+# Contributing to the guide
+
+Thank you for helping improve this guide! Content contributions, link corrections, accessibility improvements, bug fixes, and tests are all welcome.
+
+## Before you start
+
+- Follow the [Code of Conduct](CODE_OF_CONDUCT.md).
+- Check open issues before starting a large change. If none exists, open one to propose the change and agree on its scope.
+- Keep each pull request small and focused on a single goal.
+
+## Set up the project
+
+Node.js `>=22.12.0` is required.
+
+1. Fork the repository on GitHub.
+2. Clone your fork and enter the project directory.
+3. Install dependencies:
+
+   ```bash
+   npm install
+   ```
+
+4. Create a branch from the latest version of `main`:
+
+   ```bash
+   git checkout main
+   git pull origin main
+   git checkout -b docs/add-react-resources
+   ```
+
+## Branches and commits
+
+Use lowercase, hyphen-separated branch names. The prefix should describe the type of change:
+
+- `docs/add-react-resources`
+- `fix/sidebar-link`
+- `feat/add-search`
+- `chore/update-dependencies`
+
+Use [Conventional Commits](https://www.conventionalcommits.org/) for commit messages:
+
+```text
+docs(react): add testing resources
+fix(links): correct Python Clean Code URL
+feat(content): add system design guide
+test(seo): cover canonical URL metadata
+```
+
+Write a short, imperative title without a final period. Do not combine unrelated changes in one commit.
+
+## Contribute content
+
+The navigable content lives in `src/content/guide/**/*.mdx`. Every new section must include the required frontmatter: `title`, `description`, `category`, `sidebar.order`, and `references`.
+
+- Add useful, trustworthy resources relevant to technical interviews.
+- Check that every URL is valid and clearly describe each resource.
+- Do not copy copyrighted content without permission.
+- Follow the style and structure of nearby MDX files.
+
+## Validate your changes
+
+Before opening a pull request, run the applicable checks:
+
+```bash
+npm run lint
+npm run build
+npm test
+npm run verify:content
+npm run check:links
+```
+
+For visual changes, run `npm run dev` and review them in a browser. If you change interface behavior, also run `npm run test:e2e`.
+
+> The repository still has existing global formatting issues. Do not run `npm run format` across the entire project as part of a small contribution; it will be added to CI after formatting is normalized in a dedicated change.
+
+## Open a pull request
+
+1. Push your branch to your fork:
+
+   ```bash
+   git push -u origin docs/add-react-resources
+   ```
+
+2. Open a pull request against this repository's `main` branch.
+3. Use a Conventional Commits-style title, for example: `docs(react): add testing resources`.
+4. Complete the pull request template and link the related issue with `Closes #123`, when applicable.
+5. Respond to review comments and update your branch when needed.
+
+By submitting a pull request, you confirm that you have the right to contribute the content under this repository's license.

--- a/README.md
+++ b/README.md
@@ -29,6 +29,15 @@ npm run check:links
 
 Cada seccion nueva debe agregarse como `.mdx` en `src/content/guide/` con `title`, `description`, `category`, `sidebar.order` y `references`. Las referencias originales van en frontmatter y los ejemplos propios pueden agregarse con `examples` o como bloques de codigo MDX dentro del contenido.
 
+## Contributing
+
+Contributions are welcome. Read [CONTRIBUTING.md](CONTRIBUTING.md) for the local setup, branch and commit conventions, content rules, and required validation.
+
+- Suggest a new topic or resource with the [content suggestion issue template](.github/ISSUE_TEMPLATE/content_suggestion.yml), or report a problem with the [bug report template](.github/ISSUE_TEMPLATE/bug_report.yml).
+- Open focused pull requests using the [PR template](.github/pull_request_template.md). Link the related issue with `Closes #<issue-number>` when applicable.
+- For content changes, run `npm run verify:content` and `npm run check:links`; run `npm run check:links -- --fetch` to verify that reference websites respond.
+- Project skills are available in `.claude/skills/`: `create-content` for new guide pages, `create-commit` for focused Conventional Commits, and `create-pr` for preparing draft pull requests.
+
 ## Índice
 
 - [Guía para entrevistas técnicas como Ingeniero de software](#guía-para-entrevistas-técnicas-como-ingeniero-de-software)

--- a/scripts/mdx-frontmatter.mjs
+++ b/scripts/mdx-frontmatter.mjs
@@ -50,7 +50,7 @@ function parseYamlSubset(yaml) {
         const [firstKey, firstValue] = splitYamlPair(first);
         item[firstKey] = parseScalar(firstValue ?? "");
         i += 1;
-        while (i < lines.length && /^    [A-Za-z]/.test(lines[i])) {
+        while (i < lines.length && /^ {4}[A-Za-z]/.test(lines[i])) {
           const [itemKey, itemValue] = splitYamlPair(lines[i].trim());
           item[itemKey] = parseScalar(itemValue ?? "");
           i += 1;

--- a/scripts/verify-content-migration.mjs
+++ b/scripts/verify-content-migration.mjs
@@ -5,7 +5,7 @@ import { listMdxFiles, readMdxFrontmatter } from "./mdx-frontmatter.mjs";
 
 const requiredSections = {
   "Principios SOLID": "buenas-practicas/solid-principles",
-  DRY: "buenas-practicas/dry-kiss-yagni-grasp-lod",
+  DRY: "buenas-practicas/dry",
   "Clean Code": "buenas-practicas/clean-code",
   "Clean architecture": "buenas-practicas/clean-architecture",
   Angular: "buenas-practicas-en/angular",

--- a/src/content/guide/buenas-practicas/dry.mdx
+++ b/src/content/guide/buenas-practicas/dry.mdx
@@ -7,6 +7,8 @@ sidebar:
   label: "DRY"
   order: 21
 references:
+  - label: "Demystifying Software Development Principles: DRY, KISS, YAGNI, SOLID, GRASP, and LoD"
+    url: "https://levelup.gitconnected.com/demystifying-software-development-principles-dry-kiss-yagni-solid-grasp-and-lod-8606113c0313"
   - label: "The Pragmatic Programmer — DRY Principle"
     url: "https://pragprog.com/titles/tpp20/the-pragmatic-programmer-20th-anniversary-edition/"
   - label: "DRY: Don't Repeat Yourself — refactoring.guru"


### PR DESCRIPTION
Description:

  ## Summary

  Adds the contributor workflow for the project:

  - Adds `CONTRIBUTING.md` with setup, branch, commit, content, and validation guidance.
  - Adds GitHub bug-report and content-suggestion issue forms.
  - Adds a pull request template and GitHub Actions CI workflow.
  - Adds `create-commit` and `create-pr` project skills.
  - Documents contribution options and skills in the README.
  - Fixes existing lint and content-migration verification issues so CI can pass.

  ## Type of change

  - [x] Documentation or content
  - [x] Tests or maintenance

  ## Validation

  - [x] `npm run lint`
  - [ ] `npm run build` — local environment uses Node 20.19.0; this project requires Node
  22.12+. CI uses Node 22.
  - [x] `npm test`
  - [x] `npm run verify:content`
  - [x] `npm run check:links`
  - [ ] `npm run test:e2e` — interface did not change

  ## Checklist

  - [x] My PR has a small scope and a clear title.
  - [x] I followed [CONTRIBUTING.md](../CONTRIBUTING.md).
  - [x] I did not include copyrighted content without permission.
  - [x] I updated the necessary documentation.