### PR TITLE
fix(a11y): improve code block contrast in dark mode

### DIFF
--- a/astro.config.mjs
+++ b/astro.config.mjs
@@ -10,11 +10,11 @@ export default defineConfig({
   integrations: [mdx()],
   markdown: {
     shikiConfig: {
-      theme: "github-dark",
       themes: {
         light: "github-light",
         dark: "github-dark"
       },
+      defaultColor: false,
       wrap: true
     }
   },

--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -109,3 +109,19 @@ select {
   border-radius: 0.5rem;
   padding: 1rem;
 }
+
+.astro-code,
+.astro-code span {
+  color: var(--shiki-light);
+  font-style: var(--shiki-light-font-style);
+  font-weight: var(--shiki-light-font-weight);
+  text-decoration: var(--shiki-light-text-decoration);
+}
+
+:root[data-theme="dark"] .astro-code,
+:root[data-theme="dark"] .astro-code span {
+  color: var(--shiki-dark);
+  font-style: var(--shiki-dark-font-style);
+  font-weight: var(--shiki-dark-font-weight);
+  text-decoration: var(--shiki-dark-text-decoration);
+}

--- a/tests/e2e/syntax-highlighting.spec.ts
+++ b/tests/e2e/syntax-highlighting.spec.ts
@@ -7,3 +7,28 @@ test("code examples use Shiki-highlighted code blocks", async ({ page }) => {
   await expect(codeBlock).toBeVisible();
   await expect(codeBlock.locator(".line").first()).toBeVisible();
 });
+
+test("code examples use the active theme colors", async ({ page }) => {
+  await page.goto("/guia/buenas-practicas/solid-principles");
+
+  const codeBlock = page.locator("pre.astro-code").first();
+  const token = codeBlock.locator("span[style*='--shiki-dark']").first();
+  const tokenUsesThemeColor = (property: string) =>
+    token.evaluate((element, customProperty) => {
+      const styles = getComputedStyle(element);
+      const probe = document.createElement("span");
+      probe.style.color = styles.getPropertyValue(customProperty);
+      document.body.append(probe);
+      const expectedColor = getComputedStyle(probe).color;
+      probe.remove();
+      return styles.color === expectedColor;
+    }, property);
+
+  await expect(codeBlock).toHaveCSS("background-color", "rgb(17, 24, 39)");
+  expect(await tokenUsesThemeColor("--shiki-dark")).toBe(true);
+
+  await page.getByRole("button", { name: "Cambiar tema" }).click();
+
+  await expect(codeBlock).toHaveCSS("background-color", "rgb(241, 245, 249)");
+  expect(await tokenUsesThemeColor("--shiki-light")).toBe(true);
+});


### PR DESCRIPTION
## Summary

Fix the unreadable syntax highlighting in dark mode by letting the site's `data-theme` attribute select Shiki's light and dark CSS variables.

- Configure Shiki with `defaultColor: false` so it emits theme variables without default inline colors.
- Apply `--shiki-light` and `--shiki-dark` from the site stylesheet without `!important`.
- Add Playwright regression coverage for code-block backgrounds and token colors in both themes.

This keeps Shiki as the syntax highlighter while giving the existing theme system explicit control over which generated palette is active.

## Related issue

Closes #16

## Type of change

- [ ] Documentation or content
- [x] Bug fix
- [ ] New feature
- [x] Tests or maintenance

## Validation

- [x] `npm run lint`
- [x] `npm run build`
- [x] `npm test`
- [x] `npm run verify:content` (if content changes)
- [x] `npm run check:links` (if content or links change)
- [ ] `npm run test:e2e` (if the interface changes)

Focused validation passed:

- `npx playwright test tests/e2e/syntax-highlighting.spec.ts` — 2 passed.
- Manual review completed in light and dark themes.

The full E2E suite currently reports 10 passed and 1 unrelated failure in `tests/e2e/code-examples.spec.ts`. That existing test expects an “Ejemplos” heading on the SOLID page, but the current `solid-principles.mdx` frontmatter does not define `examples`. This change does not modify content or example rendering.

## Checklist

- [x] My PR has a small scope and a clear title.
- [x] I followed [CONTRIBUTING.md](../CONTRIBUTING.md).
- [x] I did not include copyrighted content without permission.
- [x] I updated the necessary documentation.