### PR TITLE
fix(sidebar): prevent scrollbar layout shift

### DIFF
--- a/src/components/Sidebar.astro
+++ b/src/components/Sidebar.astro
@@ -24,7 +24,7 @@ const activeCategory = groups.find((group) =>
 <aside
   id="guide-sidebar"
   data-sidebar
-  class="border-r border-[var(--border)] bg-[var(--panel-bg)] p-5 sticky top-0 h-screen overflow-y-auto max-[860px]:fixed max-[860px]:z-20 max-[860px]:top-16 max-[860px]:right-auto max-[860px]:bottom-0 max-[860px]:left-0 max-[860px]:w-[min(22rem,86vw)] max-[860px]:-translate-x-full max-[860px]:transition-transform max-[860px]:duration-150 max-[860px]:data-[open]:translate-x-0"
+  class="border-r border-[var(--border)] bg-[var(--panel-bg)] p-5 sticky top-0 h-screen overflow-y-auto min-[861px]:[scrollbar-gutter:stable] max-[860px]:fixed max-[860px]:z-20 max-[860px]:top-16 max-[860px]:right-auto max-[860px]:bottom-0 max-[860px]:left-0 max-[860px]:w-[min(22rem,86vw)] max-[860px]:-translate-x-full max-[860px]:transition-transform max-[860px]:duration-150 max-[860px]:data-[open]:translate-x-0"
 >
   <a class="inline-block mb-6 font-bold text-[var(--page-fg)] no-underline" href={import.meta.env.BASE_URL}>Guia de entrevistas</a>
   <nav aria-label="Secciones de la guia">

--- a/tests/e2e/sidebar-layout.spec.ts
+++ b/tests/e2e/sidebar-layout.spec.ts
@@ -1,0 +1,19 @@
+import { expect, test } from "@playwright/test";
+
+test("expanding a long sidebar group does not shift its controls", async ({ page }) => {
+  await page.setViewportSize({ width: 1280, height: 720 });
+  await page.goto("/guia/algoritmos-y-estructuras-de-datos/algoritmos");
+
+  const sidebar = page.locator("[data-sidebar]");
+  const groupToggle = page.getByRole("button", { name: "Buenas practicas en" });
+  await expect(groupToggle).toHaveAttribute("aria-expanded", "false");
+
+  const collapsedWidth = await sidebar.evaluate((element) => element.clientWidth);
+  await groupToggle.click();
+  await expect(groupToggle).toHaveAttribute("aria-expanded", "true");
+
+  await expect
+    .poll(() => sidebar.evaluate((element) => element.scrollHeight > element.clientHeight))
+    .toBe(true);
+  await expect.poll(() => sidebar.evaluate((element) => element.clientWidth)).toBe(collapsedWidth);
+});


### PR DESCRIPTION
## Summary

Prevent sidebar controls from shifting horizontally when expanding a group causes the vertical scrollbar to appear.

- Reserve stable scrollbar space on desktop viewports.
- Keep the existing mobile sidebar sizing unchanged.
- Add Playwright regression coverage for the sidebar width before and after overflow appears.

## Related issue

Closes #26

## Type of change

- [ ] Documentation or content
- [x] Bug fix
- [ ] New feature
- [x] Tests or maintenance

## Validation

- [ ] `npm run lint`
- [ ] `npm run build`
- [ ] `npm test`
- [ ] `npm run verify:content` (if content changes)
- [ ] `npm run check:links` (if content or links change)
- [x] `npm run test:e2e` (if the interface changes)

Focused validation completed:

- `npx playwright test tests/e2e/sidebar-layout.spec.ts` — 1 passed in WSL.
- Astro check — 0 errors.
- Astro production build — 51 pages built.
- ESLint passed for the changed component and test.
- Tailwind generated the responsive `scrollbar-gutter: stable` rule.

## Checklist

- [x] My PR has a small scope and a clear title.
- [x] I followed [CONTRIBUTING.md](../CONTRIBUTING.md).
- [x] I did not include copyrighted content without permission.
- [x] I updated the necessary documentation.