### PR TITLE
fix(prose): add spacing between block elements

### DIFF
--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -70,6 +70,10 @@ select {
   max-width: 72ch;
 }
 
+.prose > * + * {
+  margin-top: 1rem;
+}
+
 .prose h1,
 .prose h2,
 .prose h3,


### PR DESCRIPTION
## Summary
Code blocks and other block-level elements (paragraphs, lists) inside
`.prose` had no vertical spacing between them — Tailwind's preflight
reset zeroed out margins, and only headings had them explicitly
restored. Added a single rule (`.prose > * + *`) that applies
consistent top margin to any adjacent siblings, so spacing works for
all current and future block types without needing a rule per
element.

## Related issue
Closes #21

## Type of change
- [ ] Documentation or content
- [x] Bug fix
- [ ] New feature
- [ ] Tests or maintenance

## Validation
- [x] `npm run lint`
- [x] `npm run build`
- [x] `npm test`
- [ ] `npm run verify:content` (if content changes)
- [ ] `npm run check:links` (if content or links change)
- [ ] `npm run test:e2e` (if the interface changes)

## Checklist
- [x] My PR has a small scope and a clear title.
- [x] I followed [CONTRIBUTING.md](../CONTRIBUTING.md).
- [x] I did not include copyrighted content without permission.
- [ ] I updated the necessary documentation.